### PR TITLE
fix: align time axis under all-day row

### DIFF
--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -37,10 +37,9 @@ export const fullGridStyles = css`
 
   .ccp-weekday-header {
     display: grid;
-    grid-template-columns: repeat(var(--full-grid-days, 7), 1fr);
+    grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);
     text-align: center;
     font-weight: bold;
-    padding-left: var(--time-axis-width);
   }
 
   .ccp-weekday-label {
@@ -49,8 +48,11 @@ export const fullGridStyles = css`
 
   .ccp-all-day-row {
     display: grid;
-    grid-template-columns: repeat(var(--full-grid-days, 7), 1fr);
-    padding-left: var(--time-axis-width);
+    grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);
+  }
+
+  .ccp-time-axis-spacer {
+    border-right: 1px solid var(--line-color);
   }
 
   .ccp-all-day-cell {

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -26,6 +26,7 @@ export function renderFullGrid(
   return html`<div class="ccp-full-grid" style="--full-grid-days:${dayCount}">
     ${renderCalendarHeader(config, activeCalendars, toggleCalendar)}
     <div class="ccp-weekday-header">
+      <div class="ccp-time-axis-spacer"></div>
       ${days.map(
         (d) =>
           html`<div class="ccp-weekday-label">
@@ -33,7 +34,10 @@ export function renderFullGrid(
           </div>`,
       )}
     </div>
-    <div class="ccp-all-day-row">${days.map((d) => renderAllDayCell(d, config))}</div>
+    <div class="ccp-all-day-row">
+      <div class="ccp-time-axis-spacer"></div>
+      ${days.map((d) => renderAllDayCell(d, config))}
+    </div>
     <div class="ccp-main-grid">
       ${renderTimeAxis()}
       <div class="ccp-day-columns">


### PR DESCRIPTION
## Summary
- Ensure the time axis column aligns beneath the all-day row
- Add spacer column so weekday header starts to the right of the time axis

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6eb560a40832dbe5c2451eccc8a20