### PR TITLE
feat: show build timestamp and fix time axis alignment

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,6 +14,7 @@ const outputFilename = isProd ? 'calendar-card-pro.js' : 'calendar-card-pro-dev.
 // Get version from package.json reliably
 const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
 const version = packageJson.version;
+const buildTimestamp = new Date().toISOString();
 
 export default {
   input: 'src/calendar-card-pro.ts',
@@ -37,6 +38,7 @@ export default {
       'CURRENT_LOG_LEVEL: 3': `CURRENT_LOG_LEVEL: ${isProd ? 0 : 3}`,
       // Remove -dev suffix from component name in production
       'calendar-card-pro-dev': isProd ? 'calendar-card-pro' : 'calendar-card-pro-dev',
+      '__BUILD_TIMESTAMP__': buildTimestamp,
     }),
     json(),
     esbuild({

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -17,6 +17,7 @@ export const fullGridStyles = css`
     display: flex;
     gap: 4px;
     margin-bottom: 8px;
+    align-items: center;
   }
 
   .ccp-filter-btn {
@@ -35,12 +36,17 @@ export const fullGridStyles = css`
     opacity: 1;
   }
 
+  .ccp-build-tag {
+    margin-left: auto;
+    font-size: 0.75rem;
+    opacity: 0.6;
+  }
+
   .ccp-weekday-header {
     display: grid;
-    grid-template-columns: repeat(var(--full-grid-days, 7), 1fr);
+    grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);
     text-align: center;
     font-weight: bold;
-    padding-left: var(--time-axis-width);
   }
 
   .ccp-weekday-label {
@@ -49,12 +55,16 @@ export const fullGridStyles = css`
 
   .ccp-all-day-row {
     display: grid;
-    grid-template-columns: repeat(var(--full-grid-days, 7), 1fr);
-    padding-left: var(--time-axis-width);
+    grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);
+    min-height: 24px;
+  }
+
+  .ccp-time-axis-spacer {
+    border-right: 1px solid var(--line-color);
   }
 
   .ccp-all-day-cell {
-    min-height: 24px;
+    height: 100%;
     border-bottom: 1px solid var(--line-color);
   }
 

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -9,6 +9,8 @@ import { TemplateResult, html } from 'lit';
 import * as Types from '../config/types';
 import { calculateGridPositions } from '../utils/events';
 
+const BUILD_TIMESTAMP = '__BUILD_TIMESTAMP__';
+
 /**
  * Render the full-grid calendar structure
  */
@@ -26,6 +28,7 @@ export function renderFullGrid(
   return html`<div class="ccp-full-grid" style="--full-grid-days:${dayCount}">
     ${renderCalendarHeader(config, activeCalendars, toggleCalendar)}
     <div class="ccp-weekday-header">
+      <div class="ccp-time-axis-spacer"></div>
       ${days.map(
         (d) =>
           html`<div class="ccp-weekday-label">
@@ -33,7 +36,10 @@ export function renderFullGrid(
           </div>`,
       )}
     </div>
-    <div class="ccp-all-day-row">${days.map((d) => renderAllDayCell(d, config))}</div>
+    <div class="ccp-all-day-row">
+      <div class="ccp-time-axis-spacer"></div>
+      ${days.map((d) => renderAllDayCell(d, config))}
+    </div>
     <div class="ccp-main-grid">
       ${renderTimeAxis()}
       <div class="ccp-day-columns">
@@ -64,6 +70,7 @@ function renderCalendarHeader(
         ${entity.label || entity.entity}
       </button>`;
     })}
+    <span class="ccp-build-tag">Build: ${BUILD_TIMESTAMP}</span>
   </div>`;
 }
 


### PR DESCRIPTION
## Summary
- inject build timestamp during rollup build and render it in calendar header
- ensure time axis starts under all-day row and weekday header begins to the right

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6eb560a40832dbe5c2451eccc8a20