### PR TITLE
feat(grid): show weather in header and refine popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ Each calendar gets a filter button in the header so you can toggle its events on
 - Weekday headers include the month when `show_month` is set.
 - Weekend and today columns can be tinted with `weekend_day_color` and `today_day_color`.
 - Event blocks respect `show_time`, `show_single_allday_time`, `show_end_time`, and `show_location` configuration.
-- Tapping an event with `tap_action: expand` opens a centered popup showing title, time, location, weather, and an expandable description.
+- Weekday headers can show daily weather (icon, high, low) aligned to the top-right.
+- Tapping an event with `tap_action: expand` opens a popup (25% width/height) with stacked weather information and a scrollable description.
 - Hourly grid lines span the time axis and day columns to provide temporal context.
 
 ### Core Settings

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 - Added sizing CSS variables (`--time-axis-width`, `--hour-height`) and event positioning vars (`--col`, `--start`, `--end`, `--lane`, `--lanes`) for lane-aware widths.
 - Improved lane calculation so only overlapping events share lanes while independent events occupy full width.
 - Added a subtle 2% margin around event blocks for clearer separation.
+- Weekday headers can show daily weather aligned to the top-right (icon, high, low).
+- Event popup resized to 25% width/height with stacked weather details and scrollable description.
 
 # Calendar Card Pro v3.1.0
 

--- a/src/rendering/event-detail.ts
+++ b/src/rendering/event-detail.ts
@@ -26,12 +26,17 @@ export function openEventDetail(
   const forecast = weather
     ? Weather.findForecastForEvent(event, weather.hourly, weather.daily)
     : undefined;
+  const eventWeatherStyle = `font-size:${config.weather?.event?.font_size || '12px'};color:${config.weather?.event?.color || 'var(--primary-text-color)'};`;
+  const eventIconSize = config.weather?.event?.icon_size || '14px';
 
   render(
     html`<div class="ccp-event-detail-dialog" @click=${(e: Event) => e.stopPropagation()}>
         ${forecast
-          ? html`<div class="detail-weather">
-              <ha-icon .icon=${forecast.icon}></ha-icon>
+          ? html`<div class="detail-weather" style=${eventWeatherStyle}>
+              <ha-icon
+                style="width:${eventIconSize};height:${eventIconSize};"
+                .icon=${forecast.icon}
+              ></ha-icon>
               <span class="temp">${forecast.temperature}°</span>
               ${forecast.precipitation_probability !== undefined
                 ? html`<span class="rain">${forecast.precipitation_probability}%</span>`
@@ -41,10 +46,7 @@ export function openEventDetail(
         <div class="detail-title">${event.summary}</div>
         <div class="detail-time">${time}</div>
         ${location ? html`<div class="detail-location">${location}</div>` : ''}
-        ${event.description
-          ? html`<div class="detail-description">${event.description}</div>
-              <button class="detail-expand">Expand</button>`
-          : ''}
+        ${event.description ? html`<div class="detail-description">${event.description}</div>` : ''}
       </div>
       <style>
         .ccp-event-detail-overlay {
@@ -62,8 +64,8 @@ export function openEventDetail(
           color: var(--primary-text-color);
           padding: 16px;
           border-radius: 8px;
-          width: 50%;
-          height: 50%;
+          width: 25%;
+          height: 25%;
           overflow: auto;
           box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
         }
@@ -78,31 +80,14 @@ export function openEventDetail(
           margin-top: 8px;
         }
         .detail-description {
-          display: -webkit-box;
-          -webkit-line-clamp: 20;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-        }
-        .detail-description.expanded {
-          display: block;
-          -webkit-line-clamp: unset;
-        }
-        .detail-expand {
-          margin-top: 8px;
-          background: none;
-          border: none;
-          color: var(--primary-color);
-          cursor: pointer;
-          padding: 0;
-          font: inherit;
+          white-space: pre-wrap;
         }
         .detail-weather {
-          position: absolute;
-          top: 8px;
-          right: 8px;
           display: flex;
+          flex-direction: column;
           align-items: center;
           gap: 4px;
+          margin-bottom: 8px;
         }
         .detail-weather .rain {
           color: blue;
@@ -112,15 +97,4 @@ export function openEventDetail(
   );
 
   document.body.appendChild(overlay);
-
-  const description = overlay.querySelector('.detail-description') as HTMLElement | null;
-  const expandBtn = overlay.querySelector('.detail-expand') as HTMLButtonElement | null;
-
-  if (description && expandBtn) {
-    expandBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      description.classList.toggle('expanded');
-      expandBtn.textContent = description.classList.contains('expanded') ? 'Collapse' : 'Expand';
-    });
-  }
 }

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -53,6 +53,30 @@ export const fullGridStyles = css`
     padding: 4px 0;
   }
 
+  .ccp-weekday-cell {
+    position: relative;
+  }
+
+  .ccp-weekday-weather {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    display: flex;
+    align-items: center;
+  }
+
+  .ccp-weekday-weather ha-icon {
+    margin-right: 2px;
+  }
+
+  .ccp-weekday-weather .weather-temp-high {
+    margin-right: 2px;
+  }
+
+  .ccp-weekday-weather .weather-temp-low {
+    color: blue;
+  }
+
   .ccp-all-day-row {
     display: grid;
     grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -9,6 +9,7 @@ import { TemplateResult, html } from 'lit';
 import * as Types from '../config/types';
 import { calculateGridPositions, getEntitySetting } from '../utils/events';
 import * as FormatUtils from '../utils/format';
+import * as Weather from '../utils/weather';
 import { openEventDetail } from './event-detail';
 
 const BUILD_TIMESTAMP = '__BUILD_TIMESTAMP__';
@@ -31,12 +32,43 @@ export function renderFullGrid(
     ${renderCalendarHeader(config, activeCalendars, toggleCalendar)}
     <div class="ccp-weekday-header">
       <div class="ccp-time-axis-spacer"></div>
-      ${days.map(
-        (d) =>
-          html`<div class="ccp-weekday-label">
+      ${days.map((d) => {
+        const date = new Date(d.timestamp);
+        const showDateWeather =
+          config.weather?.entity &&
+          (config.weather.position === 'date' || config.weather.position === 'both');
+        const dailyForecast =
+          showDateWeather && weather?.daily
+            ? Weather.findDailyForecast(date, weather.daily)
+            : undefined;
+        return html`<div class="ccp-weekday-cell">
+          <div class="ccp-weekday-label">
             ${d.weekday} ${d.day}${config.show_month ? ` ${d.month}` : ''}
-          </div>`,
-      )}
+          </div>
+          ${dailyForecast
+            ? html`<div
+                class="ccp-weekday-weather"
+                style="font-size:${config.weather?.date?.font_size || '12px'};color:${config.weather
+                  ?.date?.color || 'var(--primary-text-color)'};"
+              >
+                ${config.weather?.date?.show_conditions !== false
+                  ? html`<ha-icon
+                      style="width:${config.weather?.date?.icon_size || '14px'};height:${config
+                        .weather?.date?.icon_size || '14px'};"
+                      .icon=${dailyForecast.icon}
+                    ></ha-icon>`
+                  : ''}
+                ${config.weather?.date?.show_high_temp !== false
+                  ? html`<span class="weather-temp-high">${dailyForecast.temperature}°</span>`
+                  : ''}
+                ${config.weather?.date?.show_low_temp !== false &&
+                dailyForecast.templow !== undefined
+                  ? html`<span class="weather-temp-low">${dailyForecast.templow}°</span>`
+                  : ''}
+              </div>`
+            : ''}
+        </div>`;
+      })}
     </div>
     <div class="ccp-all-day-row">
       <div class="ccp-time-axis-spacer"></div>


### PR DESCRIPTION
## Summary
- display daily weather in full-grid weekday headers
- stack weather and shrink event popup to 25% with scrollable description
- document grid-view weather and popup refinements

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b74d519504832da6f7f3f7ac2d7721