### PR TITLE
feat: refine grid event layout and weather display

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ Fine-tune the spacing and alignment of your calendar elements:
 ```yaml
 # Spacing between elements
 day_spacing: '8px' # Space between different calendar days
-event_spacing: '6px' # Internal padding within each event
+event_spacing: '6px' # Spacing around each event block
 
 # Date column alignment
 date_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
@@ -1176,7 +1176,7 @@ These examples demonstrate how Calendar Card Pro can be customized to match any 
 | `accent_color`                             | string            | `#03a9f4`                                          | Vertical line separator color                                                                                                                                                                                                                               |
 | `vertical_line_width`                      | string            | `2px`                                              | Vertical line separator width                                                                                                                                                                                                                               |
 | `day_spacing`                              | string            | `5px`                                              | Spacing between different calendar day rows (replaces row_spacing)                                                                                                                                                                                          |
-| `event_spacing`                            | string            | `4px`                                              | Vertical padding within each event                                                                                                                                                                                                                          |
+| `event_spacing`                            | string            | `4px`                                              | Spacing around each event block |
 | `additional_card_spacing`                  | string            | `0px`                                              | Additional top/bottom padding for the card                                                                                                                                                                                                                  |
 | `height`                                   | string            | `auto`                                             | Sets a fixed, exact height for the card regardless of content amount (always this height, never more or less)                                                                                                                                               |
 | `max_height`                               | string            | `none`                                             | Allows the card to grow with content up to this maximum height limit                                                                                                                                                                                        |

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -18,6 +18,7 @@ export const fullGridStyles = css`
     gap: 4px;
     margin-bottom: 8px;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   .ccp-filter-btn {
@@ -27,13 +28,12 @@ export const fullGridStyles = css`
     background: none;
     cursor: pointer;
     font: inherit;
-    opacity: 0.4;
+    width: 20%;
+    text-align: center;
   }
 
   .ccp-filter-btn.is-active {
-    background-color: var(--line-color);
     color: var(--primary-text-color);
-    opacity: 1;
   }
 
   .ccp-build-tag {
@@ -62,15 +62,17 @@ export const fullGridStyles = css`
     top: 2px;
     right: 4px;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-end;
   }
 
   .ccp-weekday-weather ha-icon {
-    margin-right: 2px;
+    margin-right: 0;
   }
 
-  .ccp-weekday-weather .weather-temp-high {
-    margin-right: 2px;
+  .ccp-weekday-weather .temps {
+    display: flex;
+    gap: 2px;
   }
 
   .ccp-weekday-weather .weather-temp-low {
@@ -90,6 +92,20 @@ export const fullGridStyles = css`
   .ccp-all-day-cell {
     height: 100%;
     border-bottom: 1px solid var(--line-color);
+    display: flex;
+    flex-direction: column;
+    gap: var(--calendar-card-event-spacing);
+    padding: var(--calendar-card-event-spacing);
+  }
+
+  .ccp-all-day-cell .ccp-event-block {
+    position: relative;
+    left: 0;
+    top: 0;
+    width: calc(100% - var(--calendar-card-event-spacing) * 2);
+    height: calc(var(--calendar-card-font-size-event) + var(--calendar-card-event-spacing) * 2);
+    margin: 0;
+    font-size: var(--calendar-card-font-size-event);
   }
 
   .ccp-main-grid {
@@ -138,19 +154,23 @@ export const fullGridStyles = css`
     --lanes: 1;
     left: calc(
       (100% / var(--full-grid-days, 7)) * var(--col) + (100% / var(--full-grid-days, 7)) *
-        (var(--lane, 0) / var(--lanes)) + (100% / var(--full-grid-days, 7)) * (1 / var(--lanes)) *
-        0.01
+        (var(--lane, 0) / var(--lanes)) + var(--calendar-card-event-spacing)
     );
-    width: calc((100% / var(--full-grid-days, 7)) * (1 / var(--lanes)) * 0.98);
-    top: calc(var(--start) * var(--hour-height) + var(--hour-height) * 0.01);
-    height: calc((var(--end) - var(--start)) * var(--hour-height) * 0.98);
+    width: calc(
+      (100% / var(--full-grid-days, 7)) * (1 / var(--lanes)) - var(--calendar-card-event-spacing) *
+        2
+    );
+    top: calc(var(--start) * var(--hour-height) + var(--calendar-card-event-spacing));
+    height: calc(
+      (var(--end) - var(--start)) * var(--hour-height) - var(--calendar-card-event-spacing) * 2
+    );
     background-color: var(--line-color);
     color: var(--primary-text-color);
     border-radius: 4px;
     padding: 2px;
     box-sizing: border-box;
     overflow: hidden;
-    font-size: 12px;
+    font-size: var(--calendar-card-font-size-event);
     display: flex;
     flex-direction: column;
   }

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -58,13 +58,20 @@ export function renderFullGrid(
                       .icon=${dailyForecast.icon}
                     ></ha-icon>`
                   : ''}
-                ${config.weather?.date?.show_high_temp !== false
-                  ? html`<span class="weather-temp-high">${dailyForecast.temperature}°</span>`
-                  : ''}
-                ${config.weather?.date?.show_low_temp !== false &&
-                dailyForecast.templow !== undefined
-                  ? html`<span class="weather-temp-low">${dailyForecast.templow}°</span>`
-                  : ''}
+                <div class="temps">
+                  ${config.weather?.date?.show_low_temp !== false &&
+                  dailyForecast.templow !== undefined
+                    ? html`<span class="weather-temp-low">${dailyForecast.templow}°</span>`
+                    : ''}
+                  ${config.weather?.date?.show_low_temp !== false &&
+                  config.weather?.date?.show_high_temp !== false &&
+                  dailyForecast.templow !== undefined
+                    ? html`<span>/</span>`
+                    : ''}
+                  ${config.weather?.date?.show_high_temp !== false
+                    ? html`<span class="weather-temp-high">${dailyForecast.temperature}°</span>`
+                    : ''}
+                </div>
               </div>`
             : ''}
         </div>`;
@@ -96,9 +103,11 @@ function renderCalendarHeader(
     ${config.entities.map((e) => {
       const entity = typeof e === 'string' ? { entity: e, color: 'var(--primary-text-color)' } : e;
       const isActive = activeCalendars.includes(entity.entity);
+      const bg = isActive ? entity.color : `color-mix(in srgb, ${entity.color} 20%, transparent)`;
+      const textColor = isActive ? 'var(--primary-text-color)' : entity.color;
       return html`<button
         class="ccp-filter-btn ${isActive ? 'is-active' : ''}"
-        style="color:${entity.color}"
+        style="background-color:${bg};color:${textColor}"
         @click=${() => toggleCalendar(entity.entity)}
       >
         ${entity.label || entity.entity}
@@ -184,7 +193,7 @@ function renderAllDayCell(
   weather: Types.WeatherForecasts,
   hass: Types.Hass | null,
 ): TemplateResult {
-  const allDayEvents = day.events.filter((e) => !e.start.dateTime && !e._isEmptyDay);
+  const allDayEvents = day.events.filter((e) => !e.start.dateTime && !e._isEmptyDay).slice(0, 3);
   return html`<div class="ccp-all-day-cell">
     ${allDayEvents.map((ev) => {
       const eventColor = ev._matchedConfig?.color || config.event_color;


### PR DESCRIPTION
## Summary
- use configurable event spacing for grid layout and standardize all-day event sizing
- color calendar filter buttons and widen them for consistent layout
- show weather with low/high temps below icons in weekday headers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b762c08cc4832d9643ba420772629a