### PR TITLE
Preserve event descriptions and raw locations in popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Each calendar gets a filter button in the header so you can toggle its events on
 - Weekend and today columns can be tinted with `weekend_day_color` and `today_day_color`.
 - Event blocks respect `show_time`, `show_single_allday_time`, `show_end_time`, and `show_location` configuration.
 - Weekday headers can show daily weather (icon, high, low) aligned to the top-right.
-- Tapping an event with `tap_action: expand` opens a popup (25% width/height) with stacked weather information and a scrollable description.
+- Tapping an event with `tap_action: expand` opens a popup (25% width/height) with stacked weather information, full location, and a scrollable description.
 - Hourly grid lines span the time axis and day columns to provide temporal context.
 
 ### Core Settings
@@ -306,6 +306,8 @@ entities:
 | allowlist              | string  | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                    |
 
 This structure gives you granular control over how information from different calendars is displayed.
+
+> **Note:** Setting `show_location: false` hides locations only in event blocks. Event detail popups always display the full location when available.
 
 #### 🔍 Event Filtering
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -16,6 +16,9 @@
 - Event popup resized to 25% width/height with stacked weather details and scrollable description.
 - Event detail pop-up now shows calendar labels, description, and location with weather based on the next full hour and configurable styling.
 
+## Fixed
+- Event detail pop-up now correctly displays location and description data even when `show_location` hides locations in event blocks.
+
 # Calendar Card Pro v3.1.0
 
 **Enhanced internationalization and improved customization.** This release significantly expands language support for the visual configuration editor while adding powerful new customization options and fixing important display issues.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -203,6 +203,10 @@ export interface CalendarEventData {
   readonly end: { readonly dateTime?: string; readonly date?: string };
   summary?: string;
   location?: string;
+  /** Unfiltered location for event details */
+  rawLocation?: string;
+  /** Full description for event details */
+  description?: string;
   _entityId?: string;
   _entityLabel?: string;
   /** Labels from all calendars this event belongs to */

--- a/src/rendering/event-detail.ts
+++ b/src/rendering/event-detail.ts
@@ -20,8 +20,8 @@ export function openEventDetail(
   overlay.addEventListener('click', () => overlay.remove());
 
   const time = FormatUtils.formatEventTime(event, config, language, hass);
-  const location = event.location
-    ? FormatUtils.formatLocation(event.location, config.remove_location_country)
+  const location = event.rawLocation
+    ? FormatUtils.formatLocation(event.rawLocation, config.remove_location_country)
     : '';
   const forecast = weather
     ? Weather.findForecastForEvent(event, weather.hourly, weather.daily)

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -226,14 +226,18 @@ export function groupEventsByDay(
         };
       }
 
+      const showLocation =
+        getEntitySetting(event._entityId, 'show_location', config, event) ?? config.show_location;
+      const rawLocation = event.location || '';
+
       eventsByDay[eventDateKey].events.push({
         summary: event.summary || '',
         time: FormatUtils.formatEventTime(event, config, language),
-        location:
-          (getEntitySetting(event._entityId, 'show_location', config, event) ??
-          config.show_location)
-            ? FormatUtils.formatLocation(event.location || '', config.remove_location_country)
-            : '',
+        location: showLocation
+          ? FormatUtils.formatLocation(rawLocation, config.remove_location_country)
+          : '',
+        rawLocation,
+        description: event.description || '',
         start: event.start,
         end: event.end,
         _entityId: event._entityId,


### PR DESCRIPTION
## Summary
- retain raw event locations and descriptions for details popup
- document that show_location only affects event blocks
- fix release notes to mention the popup bug

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76a834288832d887e350c7e4ace47