### PR TITLE
feat: add calendar navigation buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Each calendar gets a filter button in the header so you can toggle its events on
 - Empty days render as blank columns, even when `show_days_without_events` is enabled.
 - Weekday headers include the month when `show_month` is set.
 - Weekend and today columns can be tinted with `weekend_day_color` and `today_day_color`.
+- Navigate through days with `<<`, `Today`, and `>>` buttons to move backward, forward, or return to the current date.
 - Event blocks respect `show_time`, `show_single_allday_time`, `show_end_time`, and `show_location` configuration.
 - Weekday headers can show daily weather (icon, high, low) aligned to the top-right.
 - Tapping an event with `tap_action: expand` opens a popup (25% width/height) with stacked weather information, full location, and a scrollable description.

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -553,6 +553,28 @@ class CalendarCardPro extends LitElement {
   }
 
   /**
+   * Shift the calendar view by the configured number of days
+   */
+  navigateDays(offset: number): void {
+    const currentStart = EventUtils.getTimeWindow(
+      this.config.days_to_show,
+      this.config.start_date,
+    ).start;
+    currentStart.setDate(currentStart.getDate() + offset);
+    const newStart = currentStart.toISOString().split('T')[0];
+    this.config = { ...this.config, start_date: newStart };
+    this.updateEvents(true);
+  }
+
+  /**
+   * Reset the calendar view to today
+   */
+  resetToToday(): void {
+    this.config = { ...this.config, start_date: undefined };
+    this.updateEvents(true);
+  }
+
+  /**
    * Handle user action
    */
   handleAction(actionConfig: Types.ActionConfig): void {
@@ -606,6 +628,8 @@ class CalendarCardPro extends LitElement {
               this.weatherForecasts,
               this.activeCalendars,
               (entity: string) => this.toggleCalendar(entity),
+              (offset: number) => this.navigateDays(offset),
+              () => this.resetToToday(),
               this.safeHass,
             )
           : Render.renderGroupedEvents(
@@ -626,6 +650,8 @@ class CalendarCardPro extends LitElement {
               this.weatherForecasts,
               this.activeCalendars,
               (entity: string) => this.toggleCalendar(entity),
+              (offset: number) => this.navigateDays(offset),
+              () => this.resetToToday(),
               this.safeHass,
             )
           : Render.renderGroupedEvents(

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -21,6 +21,21 @@ export const fullGridStyles = css`
     flex-wrap: wrap;
   }
 
+  .ccp-nav-header {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+
+  .ccp-nav-btn {
+    padding: 4px 8px;
+    border: 1px solid var(--line-color);
+    border-radius: 4px;
+    background: none;
+    cursor: pointer;
+    font: inherit;
+  }
+
   .ccp-filter-btn {
     padding: 4px 8px;
     border: 1px solid var(--line-color);

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -11,6 +11,7 @@ import { calculateGridPositions, getEntitySetting } from '../utils/events';
 import * as FormatUtils from '../utils/format';
 import * as Weather from '../utils/weather';
 import { openEventDetail } from './event-detail';
+import * as Localize from '../translations/localize';
 
 const BUILD_TIMESTAMP = '__BUILD_TIMESTAMP__';
 
@@ -24,12 +25,25 @@ export function renderFullGrid(
   weather: Types.WeatherForecasts,
   activeCalendars: string[],
   toggleCalendar: (entity: string) => void,
+  navigateDays: (offset: number) => void,
+  resetToToday: () => void,
   hass: Types.Hass | null,
 ): TemplateResult {
   const dayCount = days.length;
 
   return html`<div class="ccp-full-grid" style="--full-grid-days:${dayCount}">
     ${renderCalendarHeader(config, activeCalendars, toggleCalendar)}
+    <div class="ccp-nav-header">
+      <button class="ccp-nav-btn" @click=${() => navigateDays(-config.days_to_show)}>
+        &lt;&lt;
+      </button>
+      <button class="ccp-nav-btn" @click=${() => resetToToday()}>
+        ${Localize.translate(language, 'today', 'Today')}
+      </button>
+      <button class="ccp-nav-btn" @click=${() => navigateDays(config.days_to_show)}>
+        &gt;&gt;
+      </button>
+    </div>
     <div class="ccp-weekday-header">
       <div class="ccp-time-axis-spacer"></div>
       ${days.map((d) => {

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -13,6 +13,7 @@
   "view": "View",
   "full_grid": "Full grid view",
   "list": "List",
+  "today": "Today",
 
   "editor": {
     "calendar_entities": "Calendar Entities",


### PR DESCRIPTION
## Summary
- add navigation handlers for shifting start date
- show << Today >> buttons in full-grid header with styling
- document new navigation feature

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7faca5354832da788c95910fa49ba