### PR TITLE
feat: improve weekday weather and all-day layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ Each calendar gets a filter button in the header so you can toggle its events on
 - Weekend and today columns can be tinted with `weekend_day_color` and `today_day_color`.
 - Navigate through days with `<<`, `Today`, and `>>` buttons to move backward, forward, or return to the current date.
 - Event blocks respect `show_time`, `show_single_allday_time`, `show_end_time`, and `show_location` configuration.
-- Weekday headers can show daily weather (icon, high, low) aligned to the top-right.
+- The all-day events area expands to fit up to three events per day and becomes scrollable when more are present.
+- Weekday headers can show daily weather (icon, high, low) in a row beneath the date, with the high temperature highlighted in red.
 - Tapping an event with `tap_action: expand` opens a popup (25% width/height) with stacked weather information, full location, and a scrollable description.
 - Hourly grid lines span the time axis and day columns to provide temporal context.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,7 +12,8 @@
 - Added sizing CSS variables (`--time-axis-width`, `--hour-height`) and event positioning vars (`--col`, `--start`, `--end`, `--lane`, `--lanes`) for lane-aware widths.
 - Improved lane calculation so only overlapping events share lanes while independent events occupy full width.
 - Added a subtle 2% margin around event blocks for clearer separation.
-- Weekday headers can show daily weather aligned to the top-right (icon, high, low).
+- Weekday headers can show daily weather in a row beneath the date (icon, high, low) with the high temperature highlighted in red.
+- All-day events area expands with the number of events (up to three) and becomes scrollable when more are present.
 - Event popup resized to 25% width/height with stacked weather details and scrollable description.
 - Event detail pop-up now shows calendar labels, description, and location with weather based on the next full hour and configurable styling.
 

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -69,20 +69,17 @@ export const fullGridStyles = css`
   }
 
   .ccp-weekday-cell {
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .ccp-weekday-weather {
-    position: absolute;
-    top: 2px;
-    right: 4px;
+    margin-top: 2px;
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-  }
-
-  .ccp-weekday-weather ha-icon {
-    margin-right: 0;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
   }
 
   .ccp-weekday-weather .temps {
@@ -94,10 +91,13 @@ export const fullGridStyles = css`
     color: blue;
   }
 
+  .ccp-weekday-weather .weather-temp-high {
+    color: red;
+  }
+
   .ccp-all-day-row {
     display: grid;
     grid-template-columns: var(--time-axis-width) repeat(var(--full-grid-days, 7), 1fr);
-    min-height: 24px;
   }
 
   .ccp-time-axis-spacer {
@@ -105,12 +105,16 @@ export const fullGridStyles = css`
   }
 
   .ccp-all-day-cell {
-    height: 100%;
     border-bottom: 1px solid var(--line-color);
     display: flex;
     flex-direction: column;
     gap: var(--calendar-card-event-spacing);
     padding: var(--calendar-card-event-spacing);
+    max-height: calc(
+      (var(--calendar-card-font-size-event) + var(--calendar-card-event-spacing) * 2) * 3 +
+        var(--calendar-card-event-spacing) * 4
+    );
+    overflow-y: auto;
   }
 
   .ccp-all-day-cell .ccp-event-block {

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -207,7 +207,7 @@ function renderAllDayCell(
   weather: Types.WeatherForecasts,
   hass: Types.Hass | null,
 ): TemplateResult {
-  const allDayEvents = day.events.filter((e) => !e.start.dateTime && !e._isEmptyDay).slice(0, 3);
+  const allDayEvents = day.events.filter((e) => !e.start.dateTime && !e._isEmptyDay);
   return html`<div class="ccp-all-day-cell">
     ${allDayEvents.map((ev) => {
       const eventColor = ev._matchedConfig?.color || config.event_color;


### PR DESCRIPTION
## Summary
- show weather conditions and temperatures beneath weekday labels with high in red
- expand all-day area based on event count and enable scrolling when more than three exist
- document weekday weather layout and dynamic all-day area

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7fc4501c0832d8428f2e0606a41f8