### PR TITLE
Fix weather icon toggle, time axis alignment, and popup layout

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -19,6 +19,9 @@
 
 ## Fixed
 - Event detail pop-up now correctly displays location and description data even when `show_location` hides locations in event blocks.
+- Weather condition icons in the event pop-up now respect `weather.event.show_conditions`.
+- Calendar source badges in the event pop-up match header styling and no longer overflow the dialog.
+- Hour labels align with the hourly grid and grid lines stop before the time labels.
 
 # Calendar Card Pro v3.1.0
 

--- a/src/rendering/event-detail.ts
+++ b/src/rendering/event-detail.ts
@@ -30,7 +30,7 @@ export function openEventDetail(
   const eventWeatherStyle = `font-size:${eventWeatherConfig.font_size || '12px'};color:${eventWeatherConfig.color || 'var(--primary-text-color)'};`;
   const eventIconSize = eventWeatherConfig.icon_size || '14px';
   const showTemp = eventWeatherConfig.show_temp !== false;
-  const showCondition = eventWeatherConfig.show_conditions === true;
+  const showConditionIcon = eventWeatherConfig.show_conditions !== false;
   const showHigh = eventWeatherConfig.show_high_temp === true;
   const showLow = eventWeatherConfig.show_low_temp === true;
   const labels =
@@ -50,10 +50,12 @@ export function openEventDetail(
     html`<div class="ccp-event-detail-dialog" @click=${(e: Event) => e.stopPropagation()}>
         ${forecast
           ? html`<div class="detail-weather" style=${eventWeatherStyle}>
-              <ha-icon
-                style="width:${eventIconSize};height:${eventIconSize};"
-                .icon=${forecast.icon}
-              ></ha-icon>
+              ${showConditionIcon && forecast.icon
+                ? html`<ha-icon
+                    style="width:${eventIconSize};height:${eventIconSize};"
+                    .icon=${forecast.icon}
+                  ></ha-icon>`
+                : ''}
               ${showTemp && forecast.temperature !== undefined
                 ? html`<span class="temp">${forecast.temperature}°</span>`
                 : ''}
@@ -63,7 +65,7 @@ export function openEventDetail(
               ${showLow && forecast.templow !== undefined
                 ? html`<span class="low">${forecast.templow}°</span>`
                 : ''}
-              ${showCondition ? html`<span class="cond">${forecast.condition}</span>` : ''}
+              ${forecast.condition ? html`<span class="cond">${forecast.condition}</span>` : ''}
               ${forecast.precipitation_probability !== undefined
                 ? html`<span class="rain">${forecast.precipitation_probability}%</span>`
                 : ''}
@@ -76,7 +78,8 @@ export function openEventDetail(
                 (l, idx) =>
                   html`<button
                     class="ccp-filter-btn"
-                    style="color:${colors[idx] || 'var(--primary-text-color)'}"
+                    style="background-color:${colors[idx] ||
+                    'var(--line-color)'};color:var(--primary-text-color)"
                   >
                     ${l}
                   </button>`,
@@ -129,6 +132,7 @@ export function openEventDetail(
           flex-direction: column;
           align-items: flex-end;
           gap: 4px;
+          max-width: calc(100% - 16px);
         }
         .ccp-filter-btn {
           padding: 4px 8px;
@@ -137,8 +141,8 @@ export function openEventDetail(
           background: none;
           cursor: pointer;
           font: inherit;
-          width: 20%;
           text-align: center;
+          max-width: 100%;
         }
         .detail-weather {
           position: absolute;

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -137,12 +137,27 @@ export const fullGridStyles = css`
     flex-direction: column;
     font-size: 12px;
     border-right: 1px solid var(--line-color);
+    position: relative;
   }
 
   .ccp-time-axis > div {
     height: var(--hour-height);
     border-top: 1px solid var(--line-color);
     box-sizing: border-box;
+    position: relative;
+  }
+
+  .ccp-time-axis > div:first-child {
+    border-top: none;
+  }
+
+  .ccp-time-axis > div span {
+    position: absolute;
+    top: 0;
+    right: 4px;
+    transform: translateY(-50%);
+    background: var(--card-background-color, white);
+    padding: 0 4px;
   }
 
   .ccp-day-columns {

--- a/src/rendering/full-grid.ts
+++ b/src/rendering/full-grid.ts
@@ -136,7 +136,10 @@ function renderCalendarHeader(
  */
 function renderTimeAxis(): TemplateResult {
   return html`<div class="ccp-time-axis">
-    ${Array.from({ length: 24 }, (_, i) => html`<div>${i.toString().padStart(2, '0')}:00</div>`)}
+    ${Array.from(
+      { length: 24 },
+      (_, i) => html`<div><span>${i.toString().padStart(2, '0')}:00</span></div>`,
+    )}
   </div>`;
 }
 


### PR DESCRIPTION
## Summary
- Hide event weather icon when `weather.event.show_conditions` is false
- Style popup calendar badges and prevent overflow
- Align time axis labels with grid lines and stop lines before labels

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7fddac0c8832d901820d220e4ccdc