### PR TITLE
fix(full-grid): prevent header overlay and pill cropping

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -25,6 +25,8 @@
 - Weather condition icons in the event pop-up now respect `weather.event.show_conditions`.
 - Calendar source badges in the event pop-up match header styling and no longer overflow the dialog.
 - Hour labels align with the hourly grid and grid lines stop before the time labels.
+- Full-grid header no longer overlays configuration dialogs by reducing its z-index.
+- All-day event pills now display full titles by matching line-height to font size.
 
 # Calendar Card Pro v3.1.0
 

--- a/src/rendering/full-grid.styles.ts
+++ b/src/rendering/full-grid.styles.ts
@@ -16,7 +16,7 @@ export const fullGridStyles = css`
   .ccp-grid-header {
     position: sticky;
     top: 0;
-    z-index: 10;
+    z-index: 1;
     background: var(--card-background-color, white);
     display: flex;
     flex-direction: column;
@@ -144,6 +144,7 @@ export const fullGridStyles = css`
     height: calc(var(--calendar-card-font-size-event) + var(--calendar-card-event-spacing) * 2);
     margin: 0;
     font-size: var(--calendar-card-font-size-event);
+    line-height: var(--calendar-card-font-size-event);
   }
 
   .ccp-main-grid {


### PR DESCRIPTION
## Summary
- lower full-grid header z-index so dialogs aren't obscured
- match all-day event pill line-height to font size
- document fixes in release notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87eccc1ec832d897337794c5db3b0